### PR TITLE
more efficient Writable.writeBytes

### DIFF
--- a/geny/src/geny/Writable.scala
+++ b/geny/src/geny/Writable.scala
@@ -28,9 +28,7 @@ trait Writable{
 object Writable extends LowPriWritable {
   implicit class StringWritable(s: String) extends Writable{
     def writeBytesTo(out: OutputStream): Unit = {
-      val writer = new java.io.OutputStreamWriter(out, StandardCharsets.UTF_8)
-      writer.write(s)
-      writer.flush()
+      s.grouped(1024).foreach(ss => out.write(ss.getBytes(StandardCharsets.UTF_8)))
     }
     override def httpContentType = Some("text/plain")
     override def contentLength = Some(Internal.encodedLength(s))


### PR DESCRIPTION
`Writable.writeBytes` unnecessarily creates an `OutputStreamWriter` and then calls `flush()` on it. This in turn flushes the downstream `OutputStream` causing massive slowdown.

You can see this via 

```scala
val lines = Iterator.range(0,1000000).map{x => x.toString + "\n"}.toSeq
os.write.over(os.pwd/"big.txt", lines)
```

which is about 10-30x slower than
```scala
os.write.over(os.pwd/"big.txt", lines.mkString("\n"))
```

The it should be calling library's responsibility to call `flush()` or `close()` to flush the stream otherwise performance is destroyed.

This fix is not enough to fix os-lib `os.write`, it needs buffered output and a stream flush as well. See separate PR.